### PR TITLE
Refactor trade types

### DIFF
--- a/app/admin/trade.rb
+++ b/app/admin/trade.rb
@@ -24,7 +24,12 @@ ActiveAdmin.register Trade do
     column :asset_holder
 
     column :type do |resource|
-      class_name = resource.type == :open ? 'bg-green-500 dark:bg-green-900' : 'bg-sky-500 dark:bg-sky-900'
+      class_name = if %i[open
+                         crypto_open].include?(resource.type)
+                     'bg-green-500 dark:bg-green-900'
+                   else
+                     'bg-sky-500 dark:bg-sky-900'
+                   end
       status_tag(resource.type, class: class_name)
     end
 

--- a/app/services/assign_fifo_open_trade_pairs_service.rb
+++ b/app/services/assign_fifo_open_trade_pairs_service.rb
@@ -4,7 +4,7 @@ class AssignFifoOpenTradePairsService < ApplicationService
   attr_accessor :close_trade_id
 
   def call
-    return if close_trade.type != :close
+    return unless close_trade.type_close?
     return if close_trade.open_trade_pairs.sum(&:amount) >= close_trade.from_amount
 
     amount_closed = BigDecimal('0')

--- a/app/services/calculate_open_price_service.rb
+++ b/app/services/calculate_open_price_service.rb
@@ -4,7 +4,7 @@ class CalculateOpenPriceService < ApplicationService
   attr_accessor :close_trade
 
   def call
-    return if close_trade.type != :close
+    return unless close_trade.type_close?
     return if open_trade_tax_base_prices.any?(&:nil?)
 
     open_amount

--- a/app/services/calculate_profit_service.rb
+++ b/app/services/calculate_profit_service.rb
@@ -4,7 +4,7 @@ class CalculateProfitService < ApplicationService
   attr_accessor :close_trade
 
   def call
-    return if close_trade.type != :close
+    return unless close_trade.type_close?
     return if open_trade_tax_base_prices.any?(&:nil?)
     return if close_trade.tax_base_price.nil?
 

--- a/app/services/create_trade_prices_service.rb
+++ b/app/services/create_trade_prices_service.rb
@@ -4,7 +4,7 @@ class CreateTradePricesService < ApplicationService
   attr_accessor :trade
 
   def call
-    return if inter_trade?
+    return if trade.type_inter?
 
     CreatePricesService.call(priceable: trade, original_currency:, original_amount:)
   end
@@ -12,18 +12,10 @@ class CreateTradePricesService < ApplicationService
   private
 
   def original_currency
-    open_trade? ? trade.from : trade.to
+    trade.type_open? ? trade.from : trade.to
   end
 
   def original_amount
-    open_trade? ? trade.from_amount : trade.to_amount
-  end
-
-  def open_trade?
-    trade.type == :open
-  end
-
-  def inter_trade?
-    trade.type == :inter
+    trade.type_open? ? trade.from_amount : trade.to_amount
   end
 end

--- a/app/services/trades/get_type_service.rb
+++ b/app/services/trades/get_type_service.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Trades
+  class GetTypeService < ApplicationService
+    attr_accessor :trade
+
+    # rubocop:disable Metrics/MethodLength
+    def call
+      return unless to && from
+
+      if fiat_close?
+        :fiat_close
+      elsif fiat_open?
+        :fiat_open
+      elsif crypto_open?
+        :crypto_open
+      elsif crypto_close?
+        :crypto_close
+      else
+        :inter
+      end
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    private
+
+    def fiat_close?
+      to.currency? && !from.currency?
+    end
+
+    def fiat_open?
+      from.currency? && !to.currency?
+    end
+
+    def crypto_open?
+      from.stablecoin? && to.crypto?
+    end
+
+    def crypto_close?
+      from.crypto? && to.stablecoin?
+    end
+
+    def to
+      trade.to
+    end
+
+    def from
+      trade.from
+    end
+  end
+end

--- a/db/migrate/20250312232122_add_type_to_trades.rb
+++ b/db/migrate/20250312232122_add_type_to_trades.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddTypeToTrades < ActiveRecord::Migration[8.0]
+  def change
+    add_column :trades, :type, :integer
+
+    add_index :trades, :type
+  end
+end

--- a/db/queue_schema.rb
+++ b/db/queue_schema.rb
@@ -11,6 +11,9 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[8.0].define(version: 1) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
+
   create_table "solid_queue_blocked_executions", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.string "queue_name", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_17_132301) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_12_232122) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
+
   create_table "asset_holders", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -120,9 +123,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_132301) do
     t.datetime "updated_at", null: false
     t.bigint "asset_holder_id", null: false
     t.bigint "user_id", null: false
+    t.integer "type"
     t.index ["asset_holder_id"], name: "index_trades_on_asset_holder_id"
     t.index ["from_id"], name: "index_trades_on_from_id"
     t.index ["to_id"], name: "index_trades_on_to_id"
+    t.index ["type"], name: "index_trades_on_type"
     t.index ["user_id"], name: "index_trades_on_user_id"
   end
 

--- a/spec/models/trade_spec.rb
+++ b/spec/models/trade_spec.rb
@@ -51,12 +51,15 @@ RSpec.describe Trade do
   end
 
   describe '#type' do
+    # Trigger before_validation callback
+    before { trade.valid? }
+
     context 'when from is a currency and to is not' do
       let(:to) { build(:asset, asset_type: AssetType.crypto) }
       let(:from) { build(:asset, asset_type: AssetType.currency) }
 
-      it 'returns :open' do
-        expect(trade.type).to eq(:open)
+      it 'returns fiat_open' do
+        expect(trade).to be_type_fiat_open
       end
     end
 
@@ -64,8 +67,8 @@ RSpec.describe Trade do
       let(:to) { build(:asset, asset_type: AssetType.currency) }
       let(:from) { build(:asset, asset_type: AssetType.crypto) }
 
-      it 'returns :close' do
-        expect(trade.type).to eq(:close)
+      it 'returns fiat_close' do
+        expect(trade).to be_type_fiat_close
       end
     end
 
@@ -73,8 +76,8 @@ RSpec.describe Trade do
       let(:from) { build(:asset, asset_type: AssetType.crypto) }
       let(:to) { build(:asset, asset_type: AssetType.crypto) }
 
-      it 'returns :inter' do
-        expect(trade.type).to eq(:inter)
+      it 'returns inter' do
+        expect(trade).to be_type_inter
       end
     end
 
@@ -82,8 +85,97 @@ RSpec.describe Trade do
       let(:from) { build(:asset, asset_type: AssetType.currency) }
       let(:to) { build(:asset, asset_type: AssetType.currency) }
 
-      it 'returns :inter' do
-        expect(trade.type).to eq(:inter)
+      it 'returns inter' do
+        expect(trade).to be_type_inter
+      end
+    end
+
+    context 'when from is a stablecoin and to is a crypto' do
+      let(:from) { build(:asset, asset_type: AssetType.stablecoin) }
+      let(:to) { build(:asset, asset_type: AssetType.crypto) }
+
+      it 'returns crypto_open' do
+        expect(trade).to be_type_crypto_open
+      end
+    end
+
+    context 'when from is a crypto and to is a stablecoin' do
+      let(:from) { build(:asset, asset_type: AssetType.crypto) }
+      let(:to) { build(:asset, asset_type: AssetType.stablecoin) }
+
+      it 'returns crypto_close' do
+        expect(trade).to be_type_crypto_close
+      end
+    end
+
+    context 'when both from and to are stablecoins' do
+      let(:from) { build(:asset, asset_type: AssetType.stablecoin) }
+      let(:to) { build(:asset, asset_type: AssetType.stablecoin) }
+
+      it 'returns inter' do
+        expect(trade).to be_type_inter
+      end
+    end
+
+    context 'when from is a stablecoin and to is a currency' do
+      let(:from) { build(:asset, asset_type: AssetType.stablecoin) }
+      let(:to) { build(:asset, asset_type: AssetType.currency) }
+
+      it 'returns fiat_close' do
+        expect(trade).to be_type_fiat_close
+      end
+    end
+
+    context 'when from is a currency and to is a stablecoin' do
+      let(:from) { build(:asset, asset_type: AssetType.currency) }
+      let(:to) { build(:asset, asset_type: AssetType.stablecoin) }
+
+      it 'returns fiat_open' do
+        expect(trade).to be_type_fiat_open
+      end
+    end
+  end
+
+  describe '#type_open?' do
+    it 'returns false' do
+      expect(trade).not_to be_type_open
+    end
+
+    context 'when trade is a fiat_open' do
+      subject(:trade) { build(:trade, type: :fiat_open) }
+
+      it 'returns true' do
+        expect(trade).to be_type_open
+      end
+    end
+
+    context 'when trade is a crypto_open' do
+      subject(:trade) { build(:trade, type: :crypto_open) }
+
+      it 'returns true' do
+        expect(trade).to be_type_open
+      end
+    end
+  end
+
+  describe '#type_close?' do
+    it 'returns false' do
+      expect(trade).not_to be_type_close
+    end
+
+    context 'when trade is a fiat_close' do
+      subject(:trade) { build(:trade, type: :fiat_close) }
+
+      it 'returns true' do
+        expect(trade).to be_type_close
+      end
+    end
+
+    context 'when trade is a crypto_close' do
+      subject(:trade) { build(:trade, type: :crypto_close) }
+
+      it 'returns true' do
+        expect(trade).to be_type_close
       end
     end
   end


### PR DESCRIPTION
- `return unless close_trade.type_close?` - these might not be needed if we can properly filter for close trades