### PR TITLE
Use CsvSectionParser for IBKR funding imports

### DIFF
--- a/app/services/ibkr/funding_parser_service.rb
+++ b/app/services/ibkr/funding_parser_service.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Ibkr
+  class FundingParserService < ApplicationService
+    attr_accessor :csv_file, :user, :custom_asset_holder
+
+    def call
+      section_data = Ibkr::CsvSectionParser.call(csv_file:, section: 'Deposits & Withdrawals')
+
+      section_data.each do |row|
+        import_funding(row)
+      end
+    end
+
+    private
+
+    def import_funding(row)
+      asset = EnsureAssetService.call(name: row['Currency'], type: AssetType.currency, user:)
+
+      return unless asset
+
+      Funding.where(
+        asset:,
+        asset_holder:,
+        date: row['Settle Date'],
+        amount: to_big_decimal(row['Amount']),
+        user:
+      ).first_or_create!
+    end
+
+    def asset_holder
+      @asset_holder ||= custom_asset_holder || AssetHolder.ibkr
+    end
+
+    def to_big_decimal(amount)
+      amount.to_s.delete(',').to_d
+    end
+  end
+end

--- a/app/services/import_activity_from_ibkr_service.rb
+++ b/app/services/import_activity_from_ibkr_service.rb
@@ -2,22 +2,21 @@
 
 require 'csv'
 
-# rubocop:disable Metrics/ClassLength
 class ImportActivityFromIbkrService < ApplicationService
   attr_accessor :csv_file, :custom_asset_holder, :user
 
   # rubocop:disable Metrics/MethodLength
-  # rubocop:disable Metrics/AbcSize
   def call
     ticker_mapping = Ibkr::TickerMapperService.call(csv_file:)
+
+    # Use FundingParserService for funding imports
+    Ibkr::FundingParserService.call(csv_file:, user:, custom_asset_holder:)
 
     CSV.foreach(csv_file.path, headers: false, liberal_parsing: true) do |row|
       if currency_trade?(row)
         import_currency_trade(row)
       elsif stock_trade?(row)
         import_stock_trade(row, ticker_mapping)
-      elsif funding?(row)
-        import_funding(row)
       elsif dividend?(row)
         import_dividend(row, ticker_mapping)
       elsif interest?(row)
@@ -27,7 +26,6 @@ class ImportActivityFromIbkrService < ApplicationService
       end
     end
   end
-  # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/MethodLength
 
   private
@@ -85,24 +83,6 @@ class ImportActivityFromIbkrService < ApplicationService
     end
   end
 
-  def funding?(row)
-    row[0] == 'Deposits & Withdrawals' && row[1] == 'Data' && row[3].present?
-  end
-
-  def import_funding(row)
-    asset = EnsureAssetService.call(name: row[2], type: AssetType.currency, user:)
-
-    return unless asset
-
-    Funding.where(
-      asset:,
-      asset_holder:,
-      date: row[3],
-      amount: to_big_decimal(row[5]),
-      user:
-    ).first_or_create!
-  end
-
   def asset_holder
     @asset_holder ||= custom_asset_holder || AssetHolder.ibkr
   end
@@ -158,4 +138,3 @@ class ImportActivityFromIbkrService < ApplicationService
     amount.delete(',').to_d
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/spec/services/ibkr/funding_parser_service_spec.rb
+++ b/spec/services/ibkr/funding_parser_service_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Ibkr::FundingParserService do
+  subject(:call) { described_class.call(csv_file:, user:) }
+
+  let(:csv_file) { fixture_file_upload(Rails.root.join('spec/fixtures/ibkr_funding.csv'), 'text/csv') }
+  let(:user) { create(:user) }
+
+  before do
+    create(:asset, ticker: 'EUR', asset_type: AssetType.currency)
+  end
+
+  it 'creates fundings' do
+    expect { call }.to change(Funding, :count).by(2)
+  end
+
+  it 'creates deposit with correct attributes' do
+    call
+
+    expect(Funding.first).to have_attributes(
+      amount: BigDecimal('10000'),
+      asset: Asset.find_by(ticker: 'EUR'),
+      date: Time.zone.parse('2023-02-09'),
+      user:
+    )
+  end
+
+  it 'creates withdrawal with correct attributes' do
+    call
+
+    expect(Funding.last).to have_attributes(
+      amount: BigDecimal('-45000'),
+      asset: Asset.find_by(ticker: 'EUR'),
+      date: Time.zone.parse('2023-12-29'),
+      user:
+    )
+  end
+
+  context 'with custom asset holder' do
+    subject(:call) { described_class.call(csv_file:, user:, custom_asset_holder:) }
+
+    let(:custom_asset_holder) { create(:asset_holder, name: 'IBKR TBSZ') }
+
+    it 'uses the custom asset holder' do
+      call
+
+      expect(Funding.first.asset_holder).to eq(custom_asset_holder)
+    end
+  end
+end


### PR DESCRIPTION
This PR refactors the IBKR funding import to use the CsvSectionParser. It creates a new FundingParserService in the Ibkr module that uses the CsvSectionParser to parse the 'Deposits & Withdrawals' section of the IBKR CSV file. This approach follows the single responsibility principle and makes the code more maintainable.